### PR TITLE
Release: 0.3.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "strawberry-django-auth"
-version = "0.3.2.1"
+version = "0.3.2.2"
 description = "Graphql authentication system with Strawberry for Django."
 license = "MIT"
 authors = ["Nir.J Benlulu <nrbnlulu@gmail.com>"]


### PR DESCRIPTION
workflows support django 3.2 and python 3.8 removed new typing features of 3.10 and slots from GqlAuthSettings.