### PR TITLE
Pinpoint import to only what is needed

### DIFF
--- a/gqlauth/core/mixins.py
+++ b/gqlauth/core/mixins.py
@@ -4,7 +4,7 @@ from typing import Type
 from django.contrib.auth import get_user_model
 from strawberry.types import Info
 
-import gqlauth
+import gqlauth.core.field_
 from gqlauth.core.utils import hide_args_kwargs, inject_arguments
 from gqlauth.user.resolvers import BaseMixin
 


### PR DESCRIPTION
There is no need to have such a broad import statement. Only import what is needed.