### PR TITLE
Update models.py

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release type: patch 
+Release type: patch
 
 
 Correctly pluralizes the "UserStatus" model as "User statuses" in Django Admin.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: patch 
+
+
+Correctly pluralizes the "UserStatus" model as "User statuses" in Django Admin.
+
+Without this change, Django Admin automatically uses the string "User statuss" as the verbose plural name.
+
+Achieved by overriding the `Meta` (Django model subclass) attribute `verbose_name_plural`.

--- a/gqlauth/models.py
+++ b/gqlauth/models.py
@@ -29,9 +29,9 @@ USER_MODEL = get_user_model()
 
 class UserStatus(models.Model):
     """A helper model that handles user account stuff."""
-    
+
     class Meta:
-        verbose_name_plural = 'User statuses'
+        verbose_name_plural = "User statuses"
 
     user = models.OneToOneField(
         django_settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="status"

--- a/gqlauth/models.py
+++ b/gqlauth/models.py
@@ -29,6 +29,9 @@ USER_MODEL = get_user_model()
 
 class UserStatus(models.Model):
     """A helper model that handles user account stuff."""
+    
+    class Meta:
+        verbose_name_plural = 'User statuses'
 
     user = models.OneToOneField(
         django_settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="status"


### PR DESCRIPTION
Correctly pluralizes the "UserStatus" model as "User statuses" in Django Admin.

Without this change, Django Admin automatically uses the string "User statuss" as the verbose plural name.