### PR TITLE
Fix bug in removal of JWT prefix

### DIFF
--- a/gqlauth/settings_type.py
+++ b/gqlauth/settings_type.py
@@ -42,8 +42,9 @@ def token_finder(request_or_scope: Union[dict, "HttpRequest"]) -> Optional[str]:
             if k == b"authorization":
                 token = v.decode()
                 break
-    if token:
-        return token.strip(JWT_PREFIX)
+    if token and token.startswith(JWT_PREFIX):
+        prefix_len = len(JWT_PREFIX)
+        return token[prefix_len:]
     return None
 
 


### PR DESCRIPTION
In the current implementation if a token happens to contain any trailing J, W or T chars they are also removed. This fix ensures we're only interested in the prefix as a substring.