### PR TITLE
Add support for Python 3.13 and Django 5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["3.2.0", "4.1.3", "4.2.8", "5.0.7"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django-version: ["3.2.0", "4.1.3", "4.2.8", "5.0.7", "5.1"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         exclude:
-          # excludes Python 3.8 and 3.9 for Django 5.0.7.
+          # excludes Python 3.8 and 3.9 for Django 5.0.7 and 5.1
           - django-version: "5.0.7"
             python-version: "3.8"
           - django-version: "5.0.7"
+            python-version: "3.9"
+          - django-version: "5.1"
+            python-version: "3.8"
+          - django-version: "5.1"
+            python-version: "3.9"
+          # Django 5.1 requires Python 3.10 or higher
+          - django-version: "5.1"
             python-version: "3.9"
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "gqlauth" }]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.13"
-Django = ">=3.2,<5.1"
+python = ">=3.8,<3.14"
+Django = ">=3.2,<5.2"
 PyJWT = ">=2.6.0,<3.0"
 pillow = { version = ">=9.5,<11.0", extras = ["captcha"] }
 django-stubs = { extras = ["compatible-mypy"], version = "^4.2.0" }
@@ -78,7 +79,7 @@ markers = [
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']
 exclude = '''
 /(
     \.eggs


### PR DESCRIPTION
This PR adds support for Python 3.13 and Django 5.1:

- Update Python version range to include 3.13
- Update Django version range to include 5.1
- Update CI configuration to test with Python 3.13 and Django 5.1
- Update black configuration to support Python 3.13
- Fix Pillow dependency version to work with Python 3.13