### PR TITLE
Add support for Django 5.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["3.2.0", "4.1.3", "4.2.8", "5.0.7"]
+        django-version: ["3.2.0", "4.1.3", "4.2.8", "5.0.7", "5.1"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
-          # excludes Python 3.8 and 3.9 for Django 5.0.7.
+          # excludes Python 3.8 and 3.9 for Django 5.0.7 and 5.1
           - django-version: "5.0.7"
             python-version: "3.8"
           - django-version: "5.0.7"
+            python-version: "3.9"
+          - django-version: "5.1"
+            python-version: "3.8"
+          - django-version: "5.1"
             python-version: "3.9"
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [{ include = "gqlauth" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.13"
-Django = ">=3.2,<5.1"
+Django = ">=3.2,<5.2"
 PyJWT = ">=2.6.0,<3.0"
 pillow = { version = ">=9.5,<11.0", extras = ["captcha"] }
 django-stubs = { extras = ["compatible-mypy"], version = "^4.2.0" }
@@ -41,7 +41,7 @@ types-cryptography = "^3.3.23"
 django-mock-queries = "^2.1.7"
 types-mock = "^5.0.0"
 types-jwt = "^0.1.0"
-types-pkg-resources = "^0.1.0"
+
 mkdocs = ">=1.3.0"
 mkdocs-markdownextradata-plugin = ">=0.2.5"
 mkdocs-material = ">=8.5.4"
@@ -78,7 +78,7 @@ markers = [
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 exclude = '''
 /(
     \.eggs


### PR DESCRIPTION
This PR adds support for Django 5.1:

- Update Django version range to include 5.1
- Update CI configuration to test with Django 5.1

Note: Python 3.13 support has been postponed until strawberry-graphql adds support for it.

## Summary by Sourcery

Add support for Django 5.1 by updating the version range in the project dependencies and adjusting the CI configuration to test against this new version.

New Features:
- Add support for Django 5.1 by updating the version range in the project dependencies.

CI:
- Update CI configuration to include testing with Django 5.1.