### PR TITLE
Fix-release-3

### DIFF
--- a/.github/workflows/management/githubref.py
+++ b/.github/workflows/management/githubref.py
@@ -8,7 +8,7 @@ def get_github_session(token: str) -> Github:
 
 
 def get_repo(g: Github) -> Repository:
-    return g.get_repo("tzevet5/Backend")
+    return g.get_repo("nrbnlulu/strawberry-django-auth")
 
 
 def get_pr(g: Github, num: int) -> PullRequest:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# CHANGELOG
-
-## 0.378.0 - 2024-12-02
-
+CHANGELOG
+=========
+0.378.0 - 2024-12-02
+--------------------
 - Add support for django 5.1
 - Drop support for django 3.2 and python >=3.9
 - Migrate from poetry to uv
@@ -9,74 +9,86 @@
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #588](https://github.com/nrbnlulu/strawberry-django-auth/pull/588/)
 
-## 0.377.0 - 2024-07-24
-
+0.377.0 - 2024-07-24
+--------------------
 resolve [#567](https://github.com/nrbnlulu/strawberry-django-auth/issues/567)resolve [#564](https://github.com/nrbnlulu/strawberry-django-auth/issues/564)Add support for CI mode when using captcha on login.this should enable to automate the sign-in process by not validation the captcha fields.
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #569](https://github.com/nrbnlulu/strawberry-django-auth/pull/569/)
 
-## 0.376.11 - 2024-04-10
-
+0.376.11 - 2024-04-10
+--------------------
 Fix register fails on channels requests. #137Do not call get_current_site() from get_email_context()Extract values from channels context.
 
 Contributed by [Hyun S. Moon](https://github.com/shmoon-kr) via [PR #519](https://github.com/nrbnlulu/strawberry-django-auth/pull/519/)
 
-## 0.376.10 - 2024-04-06
-
+0.376.10 - 2024-04-06
+--------------------
 try release 2
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #517](https://github.com/nrbnlulu/strawberry-django-auth/pull/517/)
 
-## 0.376.9 - 2024-04-06
-
+0.376.9 - 2024-04-06
+--------------------
 try release 1
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #516](https://github.com/nrbnlulu/strawberry-django-auth/pull/516/)
 
-## 0.376.8 - 2024-04-06
-
+0.376.8 - 2024-04-06
+--------------------
 This release improves the CD
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #515](https://github.com/nrbnlulu/strawberry-django-auth/pull/515/)
 
-## 0.376.7 - 2024-04-03
+0.376.7 - 2024-04-03
+--------------------
 
 Fix channels support: Fixing side effects of changing the structure of a context object
 Add gqlauth.settings_type.id_field to use in project settings
 
 Contributed by [Hyun S. Moon](https://github.com/shmoon-kr) via [PR #504](https://github.com/nrbnlulu/strawberry-django-auth/pull/504/)
 
-## 0.376.6 - 2024-03-28
+
+0.376.6 - 2024-03-28
+--------------------
 
 This release fixes mypy errors, updates linters, and added docs about `JwtSchema`.
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #500](https://github.com/nrbnlulu/strawberry-django-auth/pull/500/)
 
-## 0.376.5 - 2024-01-27
+
+0.376.5 - 2024-01-27
+--------------------
 
 Fix bug in removal of JWT prefix.
 In the current implementation if a token happens to contain any trailing J, W or T chars they are also removed.
 This fix ensures we're only interested in the prefix as a substring.
 
-## 0.376.4 - 2023-12-09
+0.376.4 - 2023-12-09
+--------------------
 
 This release adds support for Django 5.0 (https://docs.djangoproject.com/en/5.0/releases/5.0/).
 
 Contributed by [Babu Somasundaram](https://github.com/babus) via [PR #464](https://github.com/nrbnlulu/strawberry-django-auth/pull/464/)
 
-## 0.376.3 - 2023-11-21
+
+0.376.3 - 2023-11-21
+--------------------
 
 This release adds support for Python3.12
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #459](https://github.com/nrbnlulu/strawberry-django-auth/pull/459/)
 
-## 0.376.2 - 2023-08-15
+
+0.376.2 - 2023-08-15
+--------------------
 
 This release restores an accidentally deleted django migrations.
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #430](https://github.com/nrbnlulu/strawberry-django-auth/pull/430/)
 
-## 0.376.1 - 2023-08-14
+
+0.376.1 - 2023-08-14
+--------------------
 
 This release fixes the way we set the refresh token's field `revoked`.
 Previously we were passing a naive DateTime object but now we pass the timestamp with the timezone info.
@@ -85,28 +97,34 @@ fixes #395
 
 Contributed by [kurttsam](https://github.com/kurttsam) via [PR #424](https://github.com/nrbnlulu/strawberry-django-auth/pull/424/)
 
-## 0.376.0 - 2023-08-07
+
+0.376.0 - 2023-08-07
+--------------------
 
 This release removes the call for `authenticate()` on basic JWT authorization in order
 to support multiple authorization backends see issue #268.
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #420](https://github.com/nrbnlulu/strawberry-django-auth/pull/420/)
 
-## 0.375.0 - 2023-07-10
+
+0.375.0 - 2023-07-10
+--------------------
 
 This release updates to the latest version of strawberry
 and removes dependencies with strawberry-django-plus.
 
 - The directive `IsVerified` is migrated to the new field
-  extensions API and extends the django base permission
-  extension.
+extensions API and extends the django base permission
+extension.
 
 - The Channels middleware will inject the user in `request.user`
-  or `request.scope["UserOrError"]`
+or `request.scope["UserOrError"]`
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #403](https://github.com/nrbnlulu/strawberry-django-auth/pull/403/)
 
-## 0.374.6 - 2023-05-29
+
+0.374.6 - 2023-05-29
+--------------------
 
 This release fixes the way we call django's `send_mail()` previously
 we were passing the `DjangoSetting` object directly, but now we pass its value.
@@ -115,11 +133,14 @@ fixes #387
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #391](https://github.com/nrbnlulu/strawberry-django-auth/pull/391/)
 
-## 0.374.5 - 2023-05-16
+
+0.374.5 - 2023-05-16
+--------------------
 
 Dependencies update
 
-## 0.374.4 - 2023-05-07
+0.374.4 - 2023-05-07
+--------------------
 
 This is a dependencies update release.
 
@@ -127,7 +148,9 @@ If you use captcha validation you will need to
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #377](https://github.com/nrbnlulu/strawberry-django-auth/pull/377/)
 
-## 0.374.3 - 2023-04-06
+
+0.374.3 - 2023-04-06
+--------------------
 
 Correctly pluralizes the "UserStatus" model as "User statuses" in Django Admin.
 
@@ -137,13 +160,17 @@ Achieved by overriding the `Meta` (Django model subclass) attribute `verbose_nam
 
 Contributed by [Justin Masayda](https://github.com/keysmusician) via [PR #368](https://github.com/nrbnlulu/strawberry-django-auth/pull/368/)
 
-## 0.374.2 - 2023-03-25
+
+0.374.2 - 2023-03-25
+--------------------
 
 This release fixes release bot.
 
 Contributed by [ניר](https://github.com/nrbnlulu) via [PR #355](https://github.com/nrbnlulu/strawberry-django-auth/pull/355/)
 
-## 0.374.1 - 2023-03-24
+
+0.374.1 - 2023-03-24
+--------------------
 
 This release just updates dependencies.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,5 @@
 CHANGELOG
 =========
-0.378.0 - 2024-12-02
---------------------
-- Add support for django 5.1
-- Drop support for django 3.2 and python >=3.9
-- Migrate from poetry to uv
-- use taskfile instead of Makefile
-
-Contributed by [ניר](https://github.com/nrbnlulu) via [PR #587](https://github.com/nrbnlulu/strawberry-django-auth/pull/587/)
-
 0.377.0 - 2024-07-24
 --------------------
 resolve [#567](https://github.com/nrbnlulu/strawberry-django-auth/issues/567)resolve [#564](https://github.com/nrbnlulu/strawberry-django-auth/issues/564)Add support for CI mode when using captcha on login.this should enable to automate the sign-in process by not validation the captcha fields.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev-dependencies = [
     "pygithub>=2.3.0",
     "httpx>=0.27.0",
     "jinja2>=3.1.4",
+    "toml>=0.10.2",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "strawberry-django-auth"
 classifiers = [ "Environment :: Web Environment", "Intended Audience :: Developers", "License :: OSI Approved :: MIT License", "Operating System :: OS Independent", "Framework :: Django", "Programming Language :: Python :: 3.10", "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12",]
 description = "Graphql authentication system with Strawberry for Django."
-version = "0.378.0"
+version = "0.377.0"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [ "django>=5.1.3", "Django>=4.2,<5.3", "PyJWT>=2.6.0,<3.0", "strawberry-graphql-django>=0.47.0", "django-stubs[compatible-mypy]>=4.2.0",]

--- a/uv.lock
+++ b/uv.lock
@@ -1627,6 +1627,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "setuptools" },
+    { name = "toml" },
     { name = "typer" },
     { name = "types-cryptography" },
     { name = "types-jwt" },
@@ -1665,6 +1666,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4,<6" },
     { name = "pytest-django", specifier = ">=4.5.2" },
     { name = "setuptools", specifier = ">=67.6.0" },
+    { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", specifier = ">=0.12.1" },
     { name = "types-cryptography", specifier = ">=3.3.23" },
     { name = "types-jwt", specifier = ">=0.1.0" },
@@ -1697,6 +1699,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/ae/0eb2f3f1d6636bff7566c684f4407e18b41d49e847f6da38d165b6d8b19b/strawberry_graphql_django-0.50.0.tar.gz", hash = "sha256:d17d104c72f63061146d2c03ad52802f58947ac53a8e3495d0a59c66aaa8d547", size = 75888 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/d5/d857b34c129f7c691fc961681d793383ae81858a7566eee8772c0e602ceb/strawberry_graphql_django-0.50.0-py3-none-any.whl", hash = "sha256:0487d81c5239bc9cc94d485d9963efb23061ff70ed9080ca931077e94e5ad92a", size = 92347 },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Standardize the CHANGELOG formatting, correct the version number in pyproject.toml, update the build command in the release script, and add a new RELEASE.md file.

Bug Fixes:
- Correct the version number in pyproject.toml from 0.378.0 to 0.377.0.

Enhancements:
- Standardize the formatting of the CHANGELOG.md file by updating the header styles.

Build:
- Switch the build command in the release script from 'rye' to 'uv'.

Documentation:
- Add a new RELEASE.md file detailing the release type and key changes.