### PR TITLE
Update release workflow to include build step after setting remote URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,6 @@ jobs:
         run: |
           git remote set-url origin https://${{ secrets.BOT_TOKEN }}@github.com/${{ github.repository }}
           cd .github && uv run python -m workflows.management release
+          cd ..
           uv build
           uv publish --token ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,5 @@ jobs:
         run: |
           git remote set-url origin https://${{ secrets.BOT_TOKEN }}@github.com/${{ github.repository }}
           cd .github && uv run python -m workflows.management release
+          uv build
           uv publish --token ${{ secrets.PYPI_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release Type: patch
+
+Release to PyPI for #586
+See https://github.com/nrbnlulu/strawberry-django-auth/releases/tag/0.378.0


### PR DESCRIPTION
## Summary by Sourcery

Update the release workflow to include a build step after setting the remote URL and before publishing to PyPI. Add a RELEASE.md file to document the release type and link to the release notes.

CI:
- Add a build step to the release workflow after setting the remote URL.

Documentation:
- Create a new RELEASE.md file documenting the release type and providing a link to the release notes.