### PR TITLE
Remove duplicated Django dependency

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Remove duplicate Django dependency and reintroduce Django>=4.2,<5.3 support [#597](https://github.com/nrbnlulu/strawberry-django-auth/pull/597)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-Remove duplicate Django dependency and reintroduce Django>=4.2,<5.3 support [#597](https://github.com/nrbnlulu/strawberry-django-auth/pull/597)
+Remove duplicate Django dependency and reintroduce Django>=4.2,<5.3 support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Graphql authentication system with Strawberry for Django."
 version = "0.378.3"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
-dependencies = [ "django>=5.1.3", "Django>=4.2,<5.3", "PyJWT>=2.6.0,<3.0", "strawberry-graphql-django>=0.47.0", "django-stubs[compatible-mypy]>=4.2.0",]
+dependencies = [ "Django>=4.2,<5.3", "PyJWT>=2.6.0,<3.0", "strawberry-graphql-django>=0.47.0", "django-stubs[compatible-mypy]>=4.2.0",]
 [[project.authors]]
 name = "Nir Benlulu"
 email = "nrbnlulu@gmail.com"


### PR DESCRIPTION
Supersedes https://github.com/nrbnlulu/strawberry-django-auth/pull/594

## Summary by Sourcery

Remove the duplicated `django` dependency in `pyproject.toml` and update the release notes.

Bug Fixes:
- Remove duplicate `django` dependency, resolving conflicts and reintroducing Django 4.2 to 5.3 support

Documentation:
- Add release notes for the patch release