### PR TITLE
Update django dep refs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,18 @@ repos:
     hooks:
       - id: codespell
         args: ["--skip=*.json"]
+
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: ["--py310-plus"]
+
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.23.1
+    hooks:
+      - id: django-upgrade
+        args: ["--target-version", "4.2"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -9,7 +9,7 @@
 ## Requirements
 
 - Python: >= 3.10
-- Django: >= 3.2
+- Django: >= 4.2
 - Basic knowledge in [Strawberry](https://strawberry.rocks/)
 
 ---


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Django from 3.2 to 4.2.

Build:
- Add `django-upgrade` to the pre-commit config

Documentation:
- Update Django version requirement in tutorial from 3.2 to 4.2