### PR TITLE
Don't pin Django to patch version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["4.2.16", "5.0.9", "5.1.3"]
+        django-version: ["4.2", "5.0", "5.1"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Updates the CI workflow to use major.minor versions of Django instead of pinning to a specific patch version.