### PR TITLE
Remove Django 5.1 (EOL) related config residue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,6 @@ jobs:
         exclude:
           - django-version: "4.2"
             python-version: "3.14"
-          - django-version: "5.1"
-            python-version: "3.14"
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Relates to #645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated testing coverage to include additional framework and runtime version combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->